### PR TITLE
fix(rbac): Add permissions to modify deployments

### DIFF
--- a/scaligator-clusterrole.yaml
+++ b/scaligator-clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
 rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch","update","patch"]
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
Help fix #13  a little bit

Modified scaligator-clusterrole.yaml to add update and patch permissions.