### PR TITLE
feat: Add file and CLI configuration support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,6 +486,52 @@ dependencies = [
  "num-traits",
  "serde",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "concurrent-queue"
@@ -916,6 +1012,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "home"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,6 +1366,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1592,6 +1700,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openssl"
@@ -2200,6 +2314,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "anyhow",
+ "clap",
  "config",
  "dotenvy",
  "futures-util",
@@ -2445,6 +2560,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -2910,6 +3031,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
 urlencoding = "2.1.3"
 actix-web = "4"
 prometheus = "0.14.0"
+clap = { version = "4.5.47", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -72,63 +72,63 @@ It dynamically scales workloads based on custom Prometheus metrics, time-based r
    ```
 
 ### 🚀 Usage Examples
-    Here are a few examples of how to run Scaligator with different configurations.
+   Here are a few examples of how to run Scaligator with different configurations.
 
-    1. Using a Configuration File
-    You can run Scaligator with a custom configuration file by using the --config (or -c) flag.
+   1. Using a Configuration File
+   You can run Scaligator with a custom configuration file by using the --config (or -c) flag.
 
-    - Create a Config.toml file:
+   - Create a Config.toml file:
 
-    ```toml
-    prometheus_url = "[http://prometheus-operated.monitoring:9090](http://prometheus-operated.monitoring:9090)"
-    watch_namespaces = "default,scaling,dev"
-    scale_up_cpu_threshold = 0.75
-    scale_down_cpu_threshold = 0.25
-    reconcile_interval = 60
-    ```
+   ```toml
+   prometheus_url = "[http://prometheus-operated.monitoring:9090](http://prometheus-operated.monitoring:9090)"
+   watch_namespaces = "default,scaling,dev"
+   scale_up_cpu_threshold = 0.75
+   scale_down_cpu_threshold = 0.25
+   reconcile_interval = 60
+   ```
 
-    - Run Scaligator with the config file:
+   - Run Scaligator with the config file:
 
-    ```bash
-    cargo run -- -c /path/to/your/Config.toml
-    ```
+   ```bash
+   cargo run -- -c /path/to/your/Config.toml
+   ```
 
-    2. Using Environment Variables
-    Scaligator can also be configured using environment variables with the SCALIGATOR_ prefix. This is especially useful in CI/CD pipelines or Kubernetes deployments.
+   2. Using Environment Variables
+   Scaligator can also be configured using environment variables with the SCALIGATOR_ prefix. This is especially useful in CI/CD pipelines or Kubernetes deployments.
 
-    - Set the environment variables:
+   - Set the environment variables:
 
-    ```bash
-    export SCALIGATOR_PROMETHEUS_URL="[http://prometheus.monitoring.svc.cluster.local:9090](http://prometheus.monitoring.svc.cluster.local:9090)"
-    export SCALIGATOR_WATCH_NAMESPACES="production,staging"
-    export SCALIGATOR_SCALE_UP_CPU_THRESHOLD="0.8"
-    export SCALIGATOR_SCALE_DOWN_CPU_THRESHOLD="0.3"
-    ```
+   ```bash
+   export SCALIGATOR_PROMETHEUS_URL="[http://prometheus.monitoring.svc.cluster.local:9090](http://prometheus.monitoring.svc.cluster.local:9090)"
+   export SCALIGATOR_WATCH_NAMESPACES="production,staging"
+   export SCALIGATOR_SCALE_UP_CPU_THRESHOLD="0.8"
+   export SCALIGATOR_SCALE_DOWN_CPU_THRESHOLD="0.3"
+   ```
 
-    - Run Scaligator:
+   - Run Scaligator:
 
-    ```bash
-    cargo run
-    ```
+   ```bash
+   cargo run
+   ```
 
-    3. Running with Docker
-    You can run Scaligator using the pre-built Docker image. This is the recommended way to run Scaligator in a production environment.
+   3. Running with Docker
+   You can run Scaligator using the pre-built Docker image. This is the recommended way to run Scaligator in a production environment.
 
-    - Build the Docker image:
+   - Build the Docker image:
 
-    ```bash
-    docker build -t scaligator:latest .
-    ```
+   ```bash
+   docker build -t scaligator:latest .
+   ```
 
-    - Run the Docker container with environment variables:
+   - Run the Docker container with environment variables:
 
 
-    ```bash
-    docker run \
-      -e SCALIGATOR_PROMETHEUS_URL="[http://prometheus.monitoring.svc.cluster.local:9090](http://prometheus.monitoring.svc.cluster.local:9090)" \
-      -e SCALIGATOR_WATCH_NAMESPACES="default" \
-      scaligator:latest
-    ```
+   ```bash
+   docker run \
+     -e SCALIGATOR_PROMETHEUS_URL="[http://prometheus.monitoring.svc.cluster.local:9090](http://prometheus.monitoring.svc.cluster.local:9090)" \
+     -e SCALIGATOR_WATCH_NAMESPACES="default" \
+     scaligator:latest
+   ```
 
 ### 📊 Prometheus & Alertmanager Integration
    #### 1. Prometheus Scraping

--- a/README.md
+++ b/README.md
@@ -50,6 +50,86 @@ It dynamically scales workloads based on custom Prometheus metrics, time-based r
    ```
    (Optionally integrate with Prometheus & Alertmanager using scaligator-rules.yaml and scaligator-alertmanager.yaml)
 
+### ⚙️ Configuration
+   - Scaligator supports:
+      - Environment variables (override config file)
+      - Config file (config.toml)
+      - Kubernetes ConfigMap
+   - Example config:
+   ```bash
+   prometheus_url = "http://prometheus-operated.monitoring:9090"
+   watch_namespaces = ["default", "scaling", "dev"]
+   scale_up_cpu_threshold = 0.7
+   scale_down_cpu_threshold = 0.2
+   disable_dev_after = "20:00"
+   enable_dev_after = "08:00"
+
+   ```
+   - Load via ConfigMap:
+   ```bash
+   kubectl create configmap scaligator-config \
+   --from-file=config.toml=./config/config.toml
+   ```
+
+### 🚀 Usage Examples
+    Here are a few examples of how to run Scaligator with different configurations.
+
+    1. Using a Configuration File
+    You can run Scaligator with a custom configuration file by using the --config (or -c) flag.
+
+    - Create a Config.toml file:
+
+    ```toml
+    prometheus_url = "[http://prometheus-operated.monitoring:9090](http://prometheus-operated.monitoring:9090)"
+    watch_namespaces = "default,scaling,dev"
+    scale_up_cpu_threshold = 0.75
+    scale_down_cpu_threshold = 0.25
+    reconcile_interval = 60
+    ```
+
+    - Run Scaligator with the config file:
+
+    ```bash
+    cargo run -- -c /path/to/your/Config.toml
+    ```
+
+    2. Using Environment Variables
+    Scaligator can also be configured using environment variables with the SCALIGATOR_ prefix. This is especially useful in CI/CD pipelines or Kubernetes deployments.
+
+    - Set the environment variables:
+
+    ```bash
+    export SCALIGATOR_PROMETHEUS_URL="[http://prometheus.monitoring.svc.cluster.local:9090](http://prometheus.monitoring.svc.cluster.local:9090)"
+    export SCALIGATOR_WATCH_NAMESPACES="production,staging"
+    export SCALIGATOR_SCALE_UP_CPU_THRESHOLD="0.8"
+    export SCALIGATOR_SCALE_DOWN_CPU_THRESHOLD="0.3"
+    ```
+
+    - Run Scaligator:
+
+    ```bash
+    cargo run
+    ```
+
+    3. Running with Docker
+    You can run Scaligator using the pre-built Docker image. This is the recommended way to run Scaligator in a production environment.
+
+    - Build the Docker image:
+
+    ```bash
+    docker build -t scaligator:latest .
+    ```
+
+    - Run the Docker container with environment variables:
+
+
+    ```bash
+    docker run \
+      -e SCALIGATOR_PROMETHEUS_URL="[http://prometheus.monitoring.svc.cluster.local:9090](http://prometheus.monitoring.svc.cluster.local:9090)" \
+      -e SCALIGATOR_WATCH_NAMESPACES="default" \
+      scaligator:latest
+    ```
+
 ### 📊 Prometheus & Alertmanager Integration
    #### 1. Prometheus Scraping
    - Update your prometheus.yml:
@@ -104,27 +184,6 @@ It dynamically scales workloads based on custom Prometheus metrics, time-based r
 
    ```bash
    kubectl apply -f scaligator-alertmanager.yaml
-   ```
-
-### ⚙️ Configuration
-   - Scaligator supports:
-      - Environment variables (override config file)
-      - Config file (config.toml)
-      - Kubernetes ConfigMap
-   - Example config:
-   ```bash
-   prometheus_url = "http://prometheus-operated.monitoring:9090"
-   watch_namespaces = ["default", "scaling", "dev"]
-   scale_up_cpu_threshold = 0.7
-   scale_down_cpu_threshold = 0.2
-   disable_dev_after = "20:00"
-   enable_dev_after = "08:00"
-
-   ```
-   - Load via ConfigMap:
-   ```bash
-   kubectl create configmap scaligator-config \
-   --from-file=config.toml=./config/config.toml
    ```
 
 ### 🔄 How Scaling Works

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,9 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct Args {
+    /// Path of the config file 
+    #[arg(short, long)]
+    pub config: Option<String>,
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub struct Args {
-    /// Path of the config file 
+    /// Path of the config file
     #[arg(short, long)]
     pub config: Option<String>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,8 @@
+use std::path::PathBuf;
+
 use config::{Config, Environment, File};
 use serde::Deserialize;
+use tracing::warn;
 // use config::{Config, Environment, File};
 
 #[derive(Debug, Deserialize, Clone)]
@@ -16,14 +19,40 @@ pub struct AppConfig {
 }
 
 impl AppConfig {
-    pub fn from_env() -> Result<Self, config::ConfigError> {
+    pub fn configure(path: Option<PathBuf>) -> Result<Self, config::ConfigError> {
+
+        // Subtitute it if path isnt provided
+        let config_path: PathBuf = match path {
+            Some(s) =>  {
+                if !s.exists() {
+                    warn!("❔ Config file from argument doesn\'t exist, Using default config path, cli argument: {:#?}",s);
+                    let t = PathBuf::from("./Config");
+                    if !t.exists() {
+                        warn!("❔ Default config file doesn\'t exist, using Environment and default config");
+                    }
+                    t
+                }
+                else {
+                    s
+                }
+            },
+            None => {
+                let t = PathBuf::from("./Config");
+                if !t.exists() {
+                    warn!("❔ Default config file doesn\'t exist, using Environment and default config");
+                }
+                t
+            }
+        };
+
+
         let builder = Config::builder()
             .set_default("prometheus_url", "http://localhost:9090".to_string())?
             .set_default("watch_namespaces", "default, scaling, dev".to_string())?
             .set_default("scale_up_cpu_threshold", 0.7)?
             .set_default("scale_down_cpu_threshold", 0.2)?
             .set_default("reconcile_interval", 30)?
-            .add_source(File::with_name("Config").required(false))
+            .add_source(File::from(config_path).required(false))
             .add_source(Environment::with_prefix("SCALIGATOR").separator("_"));
         builder.build()?.try_deserialize()
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,31 +20,35 @@ pub struct AppConfig {
 
 impl AppConfig {
     pub fn configure(path: Option<PathBuf>) -> Result<Self, config::ConfigError> {
-
         // Subtitute it if path isnt provided
         let config_path: PathBuf = match path {
-            Some(s) =>  {
+            Some(s) => {
                 if !s.exists() {
-                    warn!("❔ Config file from argument doesn\'t exist, Using default config path, cli argument: {:#?}",s);
+                    warn!(
+                        "❔ Config file from argument doesn\'t exist, Using default config path, cli argument: {:#?}",
+                        s
+                    );
                     let t = PathBuf::from("./Config");
                     if !t.exists() {
-                        warn!("❔ Default config file doesn\'t exist, using Environment and default config");
+                        warn!(
+                            "❔ Default config file doesn\'t exist, using Environment and default config"
+                        );
                     }
                     t
-                }
-                else {
+                } else {
                     s
                 }
-            },
+            }
             None => {
                 let t = PathBuf::from("./Config");
                 if !t.exists() {
-                    warn!("❔ Default config file doesn\'t exist, using Environment and default config");
+                    warn!(
+                        "❔ Default config file doesn\'t exist, using Environment and default config"
+                    );
                 }
                 t
             }
         };
-
 
         let builder = Config::builder()
             .set_default("prometheus_url", "http://localhost:9090".to_string())?

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 mod alerts;
+mod cli;
 mod config;
 mod controller;
 mod metrics;
 mod observability;
 mod scaler;
-mod cli;
 
 use actix_web::{
     App, HttpResponse, HttpServer, Responder, get,
@@ -74,7 +74,8 @@ async fn run() -> anyhow::Result<()> {
     let args = Args::parse();
 
     info!("🔧 Loading application config...");
-    let app_config = AppConfig::configure(args.config.map(PathBuf::from)).context("Failed to load config")?;
+    let app_config =
+        AppConfig::configure(args.config.map(PathBuf::from)).context("Failed to load config")?;
     let namespaces: Vec<String> = app_config
         .watch_namespaces
         .split(",")


### PR DESCRIPTION
fixes #3 

This PR enhances configuration by adding support for a config path and command-line arguments:
- File-Based Config: Settings can be loaded from a Config file or from the cli argument.
- CLI Arguments: A --config flag now allows specifying a custom configuration path.
- Clear Precedence: Configuration is loaded in the following order: Config > Environment > Defaults.